### PR TITLE
Optimize CurrentlyPlaying fetches and color extraction; lazy-load ColorThief and improve cursor handling

### DIFF
--- a/src/components/CurrentlyPlaying.astro
+++ b/src/components/CurrentlyPlaying.astro
@@ -11,17 +11,19 @@ const { artistBannerUrl = "" } = Astro.props;
 <div class="currently-playing">
   <div
     class="container currently-playing__container relative stacked"
-    x-data={`currentlyPlaying('${artistBannerUrl}')`}
+    x-data={`currentlyPlaying(${JSON.stringify(artistBannerUrl)})`}
   >
     <div class="currently-playing__background" x-show="displayImageUrl" x-cloak>
-    	<PlaceholderImage />
+      <PlaceholderImage />
       <img
         :src="displayImageUrl"
         alt=""
         width="2180"
         height="1224"
         aria-hidden="true"
-        loading="eager"
+        loading="lazy"
+        decoding="async"
+        fetchpriority="low"
       />
       <div class="overlay" :style="overlayStyle"></div>
     </div>
@@ -71,7 +73,10 @@ const { artistBannerUrl = "" } = Astro.props;
       fetchedBannerUrl: toHttps(initialBannerUrl ?? ""),
       extractedColor: null as string | null,
       _pollId: null as ReturnType<typeof setInterval> | null,
-      _cancelColorExtract: false,
+      _lastArtistFetched: "",
+      _lastColorUrl: "",
+      _trackAbort: null as AbortController | null,
+      _bannerAbort: null as AbortController | null,
 
       get nowPlaying(): boolean {
         return isNowPlayingAttr(this.track);
@@ -120,22 +125,36 @@ const { artistBannerUrl = "" } = Astro.props;
         // @ts-ignore Alpine magic
         this.$watch("artistName", (val: string) => {
           if (val) this.fetchArtistBanner(val);
-          else this.fetchedBannerUrl = "";
+          else {
+            this._lastArtistFetched = "";
+            this.fetchedBannerUrl = "";
+          }
         });
 
         // @ts-ignore Alpine magic
         this.$watch("displayImageUrl", (val: string) => {
           if (val) this.extractColor(val);
-          else this.extractedColor = null;
+          else {
+            this._lastColorUrl = "";
+            this.extractedColor = null;
+          }
         });
       },
 
       destroy() {
         if (this._pollId !== null) clearInterval(this._pollId);
+        this._trackAbort?.abort();
+        this._bannerAbort?.abort();
       },
 
       fetchTrack() {
-        fetch(`/api/recent-tracks?t=${Date.now()}`)
+        this._trackAbort?.abort();
+        this._trackAbort = new AbortController();
+
+        fetch("/api/recent-tracks", {
+          cache: "no-store",
+          signal: this._trackAbort.signal,
+        })
           .then((r) => r.json())
           .then((data) => {
             const list = data?.recenttracks?.track;
@@ -143,27 +162,41 @@ const { artistBannerUrl = "" } = Astro.props;
               Array.isArray(list) && list.length > 0 ? list[0] : null;
             this.loading = false;
           })
-          .catch(() => {
+          .catch((error) => {
+            if (error?.name === "AbortError") return;
             this.loading = false;
           });
       },
 
       fetchArtistBanner(artist: string) {
-        fetch(`/api/artist-banner?artist=${encodeURIComponent(artist)}`)
+        if (artist === this._lastArtistFetched) return;
+
+        this._lastArtistFetched = artist;
+        this._bannerAbort?.abort();
+        this._bannerAbort = new AbortController();
+
+        fetch(`/api/artist-banner?artist=${encodeURIComponent(artist)}`, {
+          signal: this._bannerAbort.signal,
+        })
           .then((r) => r.json())
           .then((data) => {
             this.fetchedBannerUrl = data?.url ? toHttps(data.url) : "";
           })
-          .catch(() => {
+          .catch((error) => {
+            if (error?.name === "AbortError") return;
             this.fetchedBannerUrl = "";
           });
       },
 
       extractColor(url: string) {
+        if (url === this._lastColorUrl) return;
+
         extractImageColor(url).then((result) => {
           if (result.success) {
+            this._lastColorUrl = url;
             this.extractedColor = rgbToHsl(result.color);
           } else {
+            this._lastColorUrl = "";
             this.extractedColor = null;
           }
         });

--- a/src/pages/music.astro
+++ b/src/pages/music.astro
@@ -102,10 +102,19 @@ if (apiKey && fanartApiKey) {
       description="What I've been listening to lately — pulled from Last.fm. Mostly accurate, occasionally embarrassing. If it's anything out of the norm, it's probably my kids."
     />
     <script>
-      import ColorThief from "colorthief";
       import { initializeColorExtraction } from "../lib/colorExtraction";
-      (window as any).ColorThief = ColorThief;
-      initializeColorExtraction();
+
+      const initColorExtraction = async () => {
+        const { default: ColorThief } = await import("colorthief");
+        (window as any).ColorThief = ColorThief;
+        initializeColorExtraction();
+      };
+
+      if ("requestIdleCallback" in window) {
+        window.requestIdleCallback(() => void initColorExtraction());
+      } else {
+        window.setTimeout(() => void initColorExtraction(), 0);
+      }
     </script>
   </head>
   <body>
@@ -192,33 +201,48 @@ if (apiKey && fanartApiKey) {
 </style>
 
 <script is:inline>
-  document.addEventListener("mousemove", (e) => {
-    const cur = document.getElementById("cur");
-    if (cur) {
-      cur.style.left = e.clientX + "px";
-      cur.style.top = e.clientY + "px";
-    }
-  });
+  const cur = document.getElementById("cur");
+  const body = document.body;
+
+  if (cur) {
+    let rafId = 0;
+    let x = 0;
+    let y = 0;
+
+    const renderCursor = () => {
+      cur.style.left = `${x}px`;
+      cur.style.top = `${y}px`;
+      rafId = 0;
+    };
+
+    document.addEventListener(
+      "pointermove",
+      (e) => {
+        x = e.clientX;
+        y = e.clientY;
+        if (!rafId) {
+          rafId = window.requestAnimationFrame(renderCursor);
+        }
+      },
+      { passive: true },
+    );
+  }
+
   document.querySelectorAll(".prose, .body, .intro").forEach((el) => {
-    el.addEventListener("mouseenter", () =>
-      document.body.classList.add("cur-sm"),
-    );
-    el.addEventListener("mouseleave", () =>
-      document.body.classList.remove("cur-sm"),
-    );
+    el.addEventListener("mouseenter", () => body.classList.add("cur-sm"));
+    el.addEventListener("mouseleave", () => body.classList.remove("cur-sm"));
   });
+
   document
     .querySelectorAll("a:not([class]), .home-link, button, .post-item, .big-link")
     .forEach((el) => {
-      el.addEventListener(
-        "mouseenter",
-        () => document.body.classList.remove("cur-sm"),
-        document.body.classList.add("cur-lg"),
-      );
-      el.addEventListener(
-        "mouseleave",
-        () => document.body.classList.add("cur-sm"),
-        document.body.classList.remove("cur-lg"),
-      );
+      el.addEventListener("mouseenter", () => {
+        body.classList.remove("cur-sm");
+        body.classList.add("cur-lg");
+      });
+      el.addEventListener("mouseleave", () => {
+        body.classList.add("cur-sm");
+        body.classList.remove("cur-lg");
+      });
     });
 </script>


### PR DESCRIPTION
### Motivation
- Reduce redundant network and color-extraction work for the currently playing component and make fetches abortable to avoid race conditions and wasted requests.
- Improve page performance by lazy-loading the heavy `colorthief` dependency during idle time.
- Make the custom cursor performant and responsive by batching pointer updates with `requestAnimationFrame` and using passive listeners.

### Description
- Serialize the injected `artistBannerUrl` safely with `JSON.stringify` and set the background image `<img>` to `loading="lazy"`, `decoding="async"`, and `fetchpriority="low"` to reduce initial load cost.
- Add request deduplication and abort handling to `currentlyPlaying` Alpine data by introducing `_lastArtistFetched`, `_lastColorUrl`, `_trackAbort`, and `_bannerAbort`, aborting in-flight requests on new fetches, and aborting on `destroy`.
- Switch `fetchTrack` and `fetchArtistBanner` to use `AbortController` and handle abort errors; also use `cache: "no-store"` for the recent-tracks fetch and avoid refetching the same artist/banner or re-extracting the same color.
- Make image color extraction idempotent by skipping if the URL hasn't changed and store/clear `_lastColorUrl`/_lastArtistFetched appropriately in watchers.
- Lazy-load `colorthief` via dynamic `import()` and initialize color extraction on `requestIdleCallback` (with a fallback `setTimeout`) instead of importing it synchronously.
- Replace the `mousemove` cursor handling with a `pointermove` implementation that batches DOM updates using `requestAnimationFrame` and uses passive listeners, and simplify hover listeners to correctly add/remove cursor size classes.

### Testing
- Performed a local production build with `npm run build`, which completed successfully.
- Ran a TypeScript type check with `tsc --noEmit`, which succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cedb8f7200832d8e8d60c59974f912)