### PR TITLE
Fix footer pattern SVG rendering on mobile

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -521,18 +521,16 @@ const gardenNav = [
 
   .footer-pattern-wrap {
     flex: 1;
-    min-height: 80px;
-    max-height: 100px;
+    min-height: 96px;
+    height: 96px;
     overflow: hidden;
-    position: relative;
+  }
 
-    & svg {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      top: -50%;
-      opacity: 0.85;
-    }
+  .footer-pattern-wrap :global(svg) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    opacity: 0.85;
   }
 
   .footer-pattern {


### PR DESCRIPTION
### Motivation
- The footer's decorative SVG could collapse or be clipped on small/tight viewports because the wrapper relied on flexible sizing and the SVG was absolutely positioned with a negative offset.
- A stable container height and normal document-flow SVG avoids intermittent disappearance on mobile and ensures the pattern consistently fills the area.

### Description
- Updated `src/components/Footer.astro` to give the pattern container a stable size by setting `min-height: 96px` and `height: 96px` so it cannot collapse.
- Removed the previous absolute positioning and negative `top` offset for the SVG and replaced it with a global SVG rule so the SVG renders in normal flow.
- Added `.footer-pattern-wrap :global(svg)` with `display: block; width: 100%; height: 100%; opacity: 0.85;` so the pattern reliably fills its container.
- Kept `overflow: hidden` on the wrapper to preserve clipping behavior while avoiding layout collapse.

### Testing
- Attempted `npm run build` which failed in this environment because the `astro` CLI is not available in the container (`astro: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf58540b64832d965fc98a1310d06c)