### PR TITLE
Refactor footer background SVG sizing and responsive behavior

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -521,18 +521,16 @@ const gardenNav = [
 
   .footer-pattern-wrap {
     flex: 1;
-    min-height: 80px;
-    max-height: 100px;
+    min-height: 96px;
+    height: 96px;
     overflow: hidden;
-    position: relative;
+  }
 
-    & svg {
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      top: -50%;
-      opacity: 0.85;
-    }
+  .footer-pattern-wrap :global(svg) {
+    display: block;
+    width: 100%;
+    height: 100%;
+    opacity: 0.85;
   }
 
   .footer-pattern {
@@ -588,6 +586,10 @@ const gardenNav = [
   @media (max-width: 700px) {
     .footer-body {
       grid-template-columns: 1fr;
+    }
+
+    .footer-pattern-wrap {
+      display: none;
     }
 
     .footer-bottom {


### PR DESCRIPTION
### Motivation
- Improve consistency of the footer decorative pattern sizing and simplify SVG positioning to avoid overflow and layout shifts.
- Ensure the footer pattern is hidden on narrow viewports to reduce visual clutter and potential rendering cost.
- Replace absolute positioning hacks with a simpler, more predictable layout for the pattern SVG.

### Description
- Updated `.footer-pattern-wrap` sizing from `min-height: 80px; max-height: 100px;` to `min-height: 96px; height: 96px;` for a fixed pattern height.
- Removed `position: relative` from `.footer-pattern-wrap` and moved SVG rules into `.footer-pattern-wrap :global(svg)` with `display: block`, `width: 100%`, `height: 100%`, and `opacity: 0.85` instead of absolutely positioning the SVG.
- Added a media query rule to hide `.footer-pattern-wrap` on screens under `700px` by setting `display: none`.
- Kept existing footer layout and accessibility helpers intact while simplifying the pattern styling.

### Testing
- Ran a local production build via `npm run build` (Astro build) which completed successfully.
- Ran the style linter via `npm run lint` and it reported no errors.
- Verified the footer renders correctly in responsive mode (desktop and mobile widths) in a browser snapshot comparison with expected layout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf58540b64832d965fc98a1310d06c)