### PR TITLE
Add API catalog, documentation pages, robots.txt and HTML→Markdown middleware

### DIFF
--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,0 +1,18 @@
+{
+  "name": "dominickjay.com API catalog",
+  "documentation": "/docs/api",
+  "apis": [
+    {
+      "path": "/api/artist-banner",
+      "description": "Returns artist banner data used by music components."
+    },
+    {
+      "path": "/api/raindrop",
+      "description": "Returns curated links from Raindrop collections."
+    },
+    {
+      "path": "/api/recent-tracks",
+      "description": "Returns recent listening activity and related metadata."
+    }
+  ]
+}

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,3 @@
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/json"
+  Link: </docs/api>; rel="service-doc"; type="text/html"

--- a/public/docs/api/index.html
+++ b/public/docs/api/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>API Documentation | dominickjay.com</title>
+  </head>
+  <body>
+    <main>
+      <h1>API documentation</h1>
+      <p>This site exposes the following API endpoints:</p>
+      <ul>
+        <li><code>/api/artist-banner</code></li>
+        <li><code>/api/raindrop</code></li>
+        <li><code>/api/recent-tracks</code></li>
+      </ul>
+      <p>
+        See <code>/.well-known/api-catalog</code> for a machine-readable listing.
+      </p>
+    </main>
+  </body>
+</html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,31 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /404
+
+User-agent: GPTBot
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /404
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /404
+
+User-agent: Claude-Web
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /404
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /admin
+Disallow: /api/
+Disallow: /404
+
+Sitemap: https://dominickjay.com/sitemap-index.xml

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,124 @@
+import type { MiddlewareHandler } from "astro";
+
+const MARKDOWN_ACCEPT = "text/markdown";
+
+function wantsMarkdown(acceptHeader: string | null): boolean {
+  if (!acceptHeader) {
+    return false;
+  }
+
+  return acceptHeader
+    .split(",")
+    .map((part) => part.trim().toLowerCase())
+    .some((part) => part.startsWith(MARKDOWN_ACCEPT) || part === "*/*");
+}
+
+function estimateMarkdownTokens(markdown: string): number {
+  const words = markdown.trim().split(/\s+/).filter(Boolean).length;
+
+  return Math.max(1, Math.ceil(words / 0.75));
+}
+
+function htmlToMarkdown(html: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = titleMatch?.[1]?.replace(/\s+/g, " ").trim();
+  const bodyMatch = html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+  let source = bodyMatch?.[1] ?? html;
+
+  source = source
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, "")
+    .replace(/<svg[\s\S]*?<\/svg>/gi, "");
+
+  source = source
+    .replace(/<h1[^>]*>([\s\S]*?)<\/h1>/gi, "\n# $1\n\n")
+    .replace(/<h2[^>]*>([\s\S]*?)<\/h2>/gi, "\n## $1\n\n")
+    .replace(/<h3[^>]*>([\s\S]*?)<\/h3>/gi, "\n### $1\n\n")
+    .replace(/<h4[^>]*>([\s\S]*?)<\/h4>/gi, "\n#### $1\n\n")
+    .replace(/<h5[^>]*>([\s\S]*?)<\/h5>/gi, "\n##### $1\n\n")
+    .replace(/<h6[^>]*>([\s\S]*?)<\/h6>/gi, "\n###### $1\n\n")
+    .replace(
+      /<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+      "[$2]($1)",
+    )
+    .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "- $1\n")
+    .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, "$1\n\n")
+    .replace(/<br\s*\/?\s*>/gi, "\n");
+
+  source = source
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\r/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  if (title && !source.startsWith("# ")) {
+    return `# ${title}\n\n${source}`.trim();
+  }
+
+  return source;
+}
+
+function appendVaryAccept(existing: string | null): string {
+  if (!existing) {
+    return "Accept";
+  }
+
+  const parts = existing
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (parts.some((value) => value.toLowerCase() === "accept")) {
+    return parts.join(", ");
+  }
+
+  return `${parts.join(", ")}, Accept`;
+}
+
+export const onRequest: MiddlewareHandler = async ({ request }, next) => {
+  const response = await next();
+
+  if (!["GET", "HEAD"].includes(request.method)) {
+    return response;
+  }
+
+  if (!wantsMarkdown(request.headers.get("accept"))) {
+    return response;
+  }
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  if (!contentType.includes("text/html")) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("vary", appendVaryAccept(headers.get("vary")));
+  headers.set("content-type", "text/markdown; charset=utf-8");
+
+  if (request.method === "HEAD") {
+    return new Response(null, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  }
+
+  const html = await response.text();
+  const markdown = htmlToMarkdown(html);
+
+  headers.set("x-markdown-tokens", `${estimateMarkdownTokens(markdown)}`);
+
+  return new Response(markdown, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};


### PR DESCRIPTION
### Motivation

- Provide a machine-readable API catalog and simple human-facing API docs for the site's endpoints via `/.well-known/api-catalog` and `/docs/api`.
- Advertise the API catalog and docs to clients via HTTP `Link` headers so crawlers and tooling can discover them automatically.
- Offer a middleware that can convert HTML responses to Markdown when clients request `text/markdown`, and include a token estimate for downstream consumers.

### Description

- Added `public/.well-known/api-catalog` with a JSON listing of available endpoints and `public/docs/api/index.html` as basic human documentation of the API.
- Added `public/_headers` to emit `Link` relations for `/.well-known/api-catalog` and `/docs/api`, and added `public/robots.txt` with crawl rules and sitemap location.
- Introduced `src/middleware.ts` which exports `onRequest` and helper functions `wantsMarkdown`, `htmlToMarkdown`, `estimateMarkdownTokens`, and `appendVaryAccept` to detect `Accept: text/markdown`, convert HTML `<body>` (and title) to Markdown, and estimate tokens.
- Middleware updates response headers to include a `Vary` on `Accept`, sets `content-type` to `text/markdown; charset=utf-8`, sets `x-markdown-tokens` with the estimate, and correctly handles `HEAD` requests.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e91a11212c832e8bf0d8d23fa83000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine-discoverable API catalog endpoint with metadata for available endpoints
  * Introduced API documentation page describing endpoint paths and functionality
  * Enabled content negotiation to serve pages as Markdown when requested

* **Chores**
  * Configured search engine crawling rules and sitemap reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->