### PR TITLE
Require explicit Accept: text/markdown for agent Markdown responses

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,10 +7,25 @@ function wantsMarkdown(acceptHeader: string | null): boolean {
     return false;
   }
 
-  return acceptHeader
-    .split(",")
-    .map((part) => part.trim().toLowerCase())
-    .some((part) => part.startsWith(MARKDOWN_ACCEPT) || part === "*/*");
+  return acceptHeader.split(",").some((value) => {
+    const [typePart, ...paramParts] = value
+      .trim()
+      .toLowerCase()
+      .split(";")
+      .map((part) => part.trim());
+
+    if (typePart !== MARKDOWN_ACCEPT) {
+      return false;
+    }
+
+    const qValue = paramParts.find((part) => part.startsWith("q="));
+    if (!qValue) {
+      return true;
+    }
+
+    const parsed = Number.parseFloat(qValue.slice(2));
+    return Number.isFinite(parsed) && parsed > 0;
+  });
 }
 
 function estimateMarkdownTokens(markdown: string): number {


### PR DESCRIPTION
### Motivation

- Ensure Markdown is only returned to agents that explicitly request it so normal browser requests (often using wildcard `*/*`) continue to receive HTML.
- Correctly honor `q=` weighting so a header like `text/markdown;q=0` is treated as not acceptable.

### Description

- Tightened content-negotiation logic in `src/middleware.ts` by updating `wantsMarkdown` to parse each `Accept` entry into type and parameters and require the type to equal `text/markdown`.
- Added handling for `q=` parameter so only positive `q` values (or unspecified) enable Markdown, and `q=0` disables it.
- Removed the previous `*/*` fallback that could cause browsers to receive Markdown responses.
- Preserved existing middleware behavior of setting `Vary`/`Accept`, returning `Content-Type: text/markdown; charset=utf-8` for Markdown responses, including `x-markdown-tokens`, and supporting `HEAD` requests.

### Testing

- Ran the site build with `npm run build`, which completed successfully (exit code 0) and produced the server and static output despite unrelated environment/network warnings; build passed.
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e929731ff0832d93b7eb0de8b948f5)