### PR TITLE
Guard books page Hardcover status data

### DIFF
--- a/src/pages/books.astro
+++ b/src/pages/books.astro
@@ -212,25 +212,42 @@ try {
     ),
   ]);
 
-  allBooks = listInfo.data.me[0].user_books || [];
-  backlog = toReadData.data.me[0].user_books || [];
-  currentlyReading = currentDataAndList.data.me[0].user_books || [];
-  currentList = currentDataAndList.data.me[0].lists[0] || [];
-  currentListCount = currentList.books_count;
-  currentListBooks = currentList.list_books;
+  const me = currentDataAndList.data?.me?.[0];
+  const list = me?.lists?.[0];
+
+  allBooks = listInfo.data?.me?.[0]?.user_books ?? [];
+  backlog = toReadData.data?.me?.[0]?.user_books ?? [];
+  currentlyReading = me?.user_books ?? [];
+  currentList = list ?? [];
+  currentListCount = list?.books_count ?? 0;
+  currentListBooks = list?.list_books ?? [];
 } catch (error) {
   console.error(error);
   // Expected output: ReferenceError: nonExistentFunction is not defined
   // (Note: the exact output may be browser-dependent)
 }
+const getListBookUserBook = (listBook) => listBook?.book?.user_books?.[0] ?? null;
+const getListBookStatus = (listBook) =>
+  getListBookUserBook(listBook)?.user_book_status?.slug;
+const getPrimaryAuthor = (book) =>
+  book?.contributions?.[0]?.author?.name || "Unknown Author";
+
 const readCount = currentListBooks.filter(
-  (book) => book.book.user_books[0].user_book_status.slug == "read",
+  (book) => getListBookStatus(book) === "read",
 );
+const currentlyReadingListBooks = currentListBooks
+  ?.slice()
+  .reverse()
+  .filter((book) => getListBookStatus(book) === "currently-reading");
+const queuedListBooks = currentListBooks?.filter((book) => {
+  const status = getListBookStatus(book);
+  return status !== "currently-reading" && status !== "read";
+});
 
 let booksByYear = allBooks.reduce((acc, entry) => {
   const title = entry.book.title;
 
-  entry.user_book_reads.forEach((read) => {
+  entry.user_book_reads?.forEach((read) => {
     if (read.finished_at) {
       const year = new Date(read.finished_at).getFullYear();
       if (!acc[year]) acc[year] = [];
@@ -240,8 +257,8 @@ let booksByYear = allBooks.reduce((acc, entry) => {
         acc[year].push({
           id: entry.book.id,
           title,
-          author: entry.book.contributions[0].author.name,
-          finished: entry.user_book_reads[0].finished_at,
+          author: getPrimaryAuthor(entry.book),
+          finished: entry.user_book_reads?.[0]?.finished_at,
         });
         // console.log(acc[year]);
       }
@@ -333,36 +350,23 @@ const ogImage = getImagePath({ url, site });
             <h2 class="h2 col-span-full mb-[24px]">Currently Reading</h2>
             <ol class="post-list feature-list flow" style="--flow-space: 0;">
               {
-                currentListBooks?.slice().reverse().map(
-                  (book) =>
-                    book.book.user_books[0].user_book_status.slug ==
-                      "currently-reading" && (
-                      <BookItem
-                        title={book.book.title}
-                        author={
-                          book.book.contributions[0]?.author.name ||
-                          "Unknown Author"
-                        }
-                        rating={book.book.rating}
-                        cover={book.book.cover}
-                        started={
-                          book.book.user_books[0]?.user_book_reads[0]
-                            ?.started_at
-                        }
-                        finished={
-                          book.book.user_books[0]?.user_book_reads[0]
-                            ?.finished_at
-                        }
-                        status={book.book.user_books[0].user_book_status.slug}
-                        showStrikethrough={
-                          book.book.user_books[0].user_book_status.slug ===
-                          "read"
-                            ? true
-                            : false
-                        }
-                      />
-                    ),
-                )
+                currentlyReadingListBooks.map((book) => {
+                  const userBook = getListBookUserBook(book);
+                  const status = getListBookStatus(book);
+
+                  return (
+                    <BookItem
+                      title={book.book.title}
+                      author={getPrimaryAuthor(book.book)}
+                      rating={book.book.rating}
+                      cover={book.book.cover}
+                      started={userBook?.user_book_reads?.[0]?.started_at}
+                      finished={userBook?.user_book_reads?.[0]?.finished_at}
+                      status={status}
+                      showStrikethrough={status === "read"}
+                    />
+                  );
+                })
               }
             </ol>
           </div>
@@ -371,42 +375,25 @@ const ogImage = getImagePath({ url, site });
             <h2 class="h2 col-span-full mb-[24px]">2026 Reading List</h2>
             <ol class="post-list feature-list flow" style="--flow-space: 0;">
               {
-                currentListBooks
-                  ?.filter(
-                    (book) =>
-                      book.book.user_books[0].user_book_status.slug !==
-                        "currently-reading" &&
-                      book.book.user_books[0].user_book_status.slug !== "read",
-                  )
-                  ?.map((book, i) => (
+                queuedListBooks.map((book, i) => {
+                  const userBook = getListBookUserBook(book);
+                  const status = getListBookStatus(book);
+
+                  return (
                     <BookItem
                       i={String(i + 1).padStart(2, "0")}
                       title={book.book.title}
-                      author={
-                        book.book.contributions[0]?.author.name ||
-                        "Unknown Author"
-                      }
+                      author={getPrimaryAuthor(book.book)}
                       rating={book.book.rating}
                       cover={book.book.cover}
-                      queued={
-                        book.book.user_books[0].user_book_status.slug === "read"
-                          ? true
-                          : false
-                      }
-                      started={
-                        book.book.user_books[0]?.user_book_reads[0]?.started_at
-                      }
-                      finished={
-                        book.book.user_books[0]?.user_book_reads[0]?.finished_at
-                      }
-                      status={book.book.user_books[0].user_book_status.slug}
-                      showStrikethrough={
-                        book.book.user_books[0].user_book_status.slug === "read"
-                          ? true
-                          : false
-                      }
+                      queued={status === "read"}
+                      started={userBook?.user_book_reads?.[0]?.started_at}
+                      finished={userBook?.user_book_reads?.[0]?.finished_at}
+                      status={status}
+                      showStrikethrough={status === "read"}
                     />
-                  ))
+                  );
+                })
               }
             </ol>
           </div>
@@ -482,10 +469,7 @@ const ogImage = getImagePath({ url, site });
                         i={String(i + 1).padStart(2, "0")}
                         key={book.book.id}
                         title={book.book.title}
-                        author={
-                          book.book.contributions[0]?.author.name ||
-                          "Unknown Author"
-                        }
+                        author={getPrimaryAuthor(book.book)}
                         rating={book.book.rating}
                         cover={book.book.cover}
                       />


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes when Hardcover GraphQL responses are missing fields that the books page previously accessed directly, which caused errors like `Cannot read properties of undefined (reading 'user_book_status')`.
- Make the books page resilient during prerender/build when authenticated API data or nested arrays like `user_books` may be absent.

### Description
- Use optional chaining and nullish coalescing to safely unwrap GraphQL responses for `me`, `lists`, `user_books`, and `list_books` in `src/pages/books.astro`.
- Add helper functions `getListBookUserBook`, `getListBookStatus`, and `getPrimaryAuthor` to centralize safe access to nested `user_books` and author data.
- Precompute `currentlyReadingListBooks` and `queuedListBooks` using the safe helpers and replace direct `user_books[0]` indexing in the render loops with these filtered lists.
- Make read-history grouping defensive by using `?.` on `user_book_reads` and using `getPrimaryAuthor` when author info might be missing.

### Testing
- Ran `npm run build`; the build completed successfully and produced the usual environment/network warnings and a CSS pseudo-class warning, but the site built without the earlier runtime crash.
- Attempted to run `npx astro check src/pages/books.astro`, but the check prompt requested installation of `@astrojs/check`/`typescript` interactively so it was not executed non-interactively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff92cde460832d8e81c875e1a8567f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the books page to use safer data handling patterns and helper functions for deriving book information from backend data, reducing reliance on direct array indexing and making the code more resilient to data structure changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dominickjay/dominickjay.com/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->